### PR TITLE
Review fixes: output-pipeline robustness + per-frame allocation cuts

### DIFF
--- a/docs/code-review-findings.md
+++ b/docs/code-review-findings.md
@@ -1,0 +1,225 @@
+# Code Review Findings — Backlog
+
+Source: a multi-agent code review of land2port (5 reviewers across crop geometry,
+the VideoProcessor strategies, the output pipeline, performance, and Rust
+idioms/robustness; 54 raw findings synthesized and prioritized).
+
+The high-value **robustness + per-frame allocation** cluster has already been
+addressed (see commit "Harden output pipeline + cut per-frame allocations"):
+encoder finalize-on-drop, fps-probe fallback surfacing, crop-rect clamping,
+even output dims, three-head NaN/order safety, source validation, `into_rgb8`/
+`crop_imm`, cut-detection borrow, headless `Cow`, and `VecDeque` history.
+
+This document tracks the **remaining** findings — mostly design/quality and
+lower-leverage performance — that were intentionally left out of that pass.
+Line references are approximate (the codebase shifted after the first pass);
+treat the module/function as authoritative.
+
+> Note on performance: profiling showed the pipeline is **video-decode-bound**
+> (~37s of a ~40s run is ffmpeg decode inside the usls `DataLoader`), and a
+> VideoToolbox hardware-decode spike was a net loss because the DataLoader
+> already pipelines software decode on a background thread. So the performance
+> items below reduce CPU/allocator pressure but will **not** move wall-clock on
+> this workload — pursue them for cleanliness/memory, not speed.
+
+---
+
+## Theme: Smoothing strategy design & coupling
+
+### Don't let `--smooth-duration 0` silently disable Ball/Simple smoothing
+- **Impact:** medium · **Effort:** medium · **Kind:** robustness
+- **Where:** `video_processor.rs` (the `smooth_duration_frames > 0` gate in `process_video`)
+- **Why:** the loop only calls `process_frame_with_smoothing` when
+  `smooth_duration_frames > 0`, but the Simple and Ball processors ignore that
+  value entirely (underscored param). So `--smooth-duration 0` silently turns off
+  the ball's 3-frame prediction and simple previous-frame comparison, neither of
+  which conceptually depends on a duration.
+- **Suggestion:** always call `process_frame_with_smoothing` and let the History
+  processor degenerate to passthrough internally when `smooth_duration_frames == 0`,
+  or move the "no smoothing" fast path into the History processor only.
+
+### Interpolate all four crop fields, not just X
+- **Impact:** medium · **Effort:** medium · **Kind:** bug
+- **Where:** `video_processor_utils.rs` `interpolate_crop_results` (Single→Single)
+- **Why:** only `x` is eased; `y`/`width`/`height` jump to the destination at
+  t=0, so any transition that changes height/width/vertical framing shows a
+  visible vertical/zoom pop at the start of an otherwise-smooth pan.
+- **Suggestion:** interpolate `x, y, width, height` with the same `t`. If freezing
+  was deliberate for stability, gate it — only freeze a field when start and dest
+  differ by less than the smooth threshold, so genuine size/vertical changes ease too.
+
+### Ease toward the latest crop in `finalize` instead of holding the stale crop
+- **Impact:** medium · **Effort:** medium · **Kind:** design
+- **Where:** `history_smoothing_video_processor.rs` `finalize_processing`
+- **Why:** trailing buffered frames are flushed using `prev_crop`, freezing the
+  end of the video on the pre-transition framing (the frames were buffered
+  *because* a transition was pending). Worse, if `previous_crop` is `None` at end,
+  buffered frames are dropped entirely — output shorter than source, desyncing
+  the audio mux under `--add-captions`.
+- **Suggestion:** interpolate from `prev_crop` toward the most recent `latest_crop`
+  over the remaining frames (reuse `process_history_with_interpolation`), and
+  flush remaining history even when `previous_crop` is `None` (fall back to a
+  centered/identity crop) so output frame count == input frame count.
+
+### Pull shared smoothing state into a common struct/helper
+- **Impact:** medium · **Effort:** medium · **Kind:** design
+- **Where:** the three processor structs (`history_/simple_/ball_…`)
+- **Why:** all three independently declare `previous_crop`; two declare a
+  "previous image" field with inconsistent names (`last_image` vs
+  `most_recent_image`) plus a `CutDetector`. The end-of-frame update (set
+  previous_crop, set previous image, write frame) is copy-pasted with naming
+  drift, so fixes must be remembered in each.
+- **Suggestion:** introduce a small `SmoothingState { previous_crop, previous_image }`
+  (optionally the `CutDetector`) embedded in each processor, or a default-provided
+  trait helper, so the strategies differ only in the crop-selection decision.
+
+---
+
+## Theme: Memory & lower-leverage performance
+
+### Don't store full-resolution frames in `CropHistory`
+- **Impact:** medium · **Effort:** large · **Kind:** design
+- **Where:** `history.rs` `FrameData`; `history_smoothing_video_processor.rs` (the `img.clone()` into history)
+- **Why:** each `FrameData` holds a full owned `Image`, so up to
+  `smooth_duration_frames` (~30–60) full-res frames live in RAM (~180–360 MB at
+  1080p, 4× at 4K), each entering via a clone and later re-cloned in
+  `create_cropped_image`. Only the `CropResult` actually needs buffering for the
+  smoothing decision. **This is the dominant peak-RSS contributor.**
+- **Suggestion:** decouple the smoothing decision (a cheap `CropResult` ring) from
+  pixel storage — buffer only crop decisions and stream frames through a bounded
+  ring, or store `Arc<Image>` so frames are shared rather than deep-copied. At
+  minimum, move (not clone) the owned current `Image` into history.
+
+### Run cut detection on a downscaled thumbnail
+- **Impact:** medium · **Effort:** medium · **Kind:** performance
+- **Where:** `image.rs` `CutDetector::is_cut`
+- **Why:** `rgb_hybrid_compare` runs an SSIM-style structural+color compare over
+  the entire full-res frame every frame just to produce one "cut?" scalar — an
+  O(w·h) pass that scales with resolution. The decision is robust to heavy downscaling.
+- **Suggestion:** maintain a small thumbnail (e.g. 256×144) per frame and compare
+  thumbnails; store only the thumbnail as "previous" (also shrinks the
+  `last_image` cost). ~50–100× cheaper compare, no material decision change.
+
+### Run the OCR/text model batched instead of per-frame with a clone
+- **Impact:** medium · **Effort:** medium · **Kind:** performance
+- **Where:** `video_processor.rs` (the `keep_text`/`prioritize_text` block)
+- **Why:** with `prioritize_text`, `text_model.forward(&[image.clone()])` runs
+  every frame — a full-frame clone plus a separate unbatched inference, sequential
+  with YOLO (which is already batched).
+- **Suggestion:** when text handling is active, run the OCR model over the same
+  batch the frame source yields (`text_model.forward(&images)`) once per batch,
+  and pass a borrowed image rather than cloning.
+
+### Default per-frame resize to a cheaper filter; Lanczos3 behind `--high-quality`
+- **Impact:** medium · **Effort:** medium · **Kind:** performance
+- **Where:** `image.rs` (the `resize(...)` calls in `create_cropped_image`)
+- **Why:** every emitted frame goes through `Lanczos3`, the slowest filter in the
+  `image` crate; the quality difference vs Triangle/CatmullRom is usually
+  imperceptible in motion video.
+- **Suggestion:** default to `Triangle`/`CatmullRom`, gate `Lanczos3` behind an
+  opt-in `--high-quality`, or use `fast_image_resize` (SIMD) for a large speedup
+  at equivalent quality. Benchmark on a representative clip.
+
+### Cache the `RUST_LOG` debug check once
+- **Impact:** low · **Effort:** small · **Kind:** performance
+- **Where:** `video_processor_utils.rs` `is_debug_enabled` (~30 call sites)
+- **Why:** every `debug_println` does `env::var("RUST_LOG")` (getenv + String
+  alloc) plus `.to_lowercase()` (another alloc), even when debug is off; several
+  fire per frame.
+- **Suggestion:** cache the boolean once via `OnceLock`/`LazyLock`, or switch to
+  `log`/`tracing` which compile the level check to a cheap atomic and format lazily.
+
+---
+
+## Theme: Validation, tests & correctness polish
+
+### Validate CLI numeric arguments
+- **Impact:** medium · **Effort:** small · **Kind:** robustness
+- **Where:** `cli.rs` numeric args; checked early in `main`
+- **Why:** `smooth_percentage`, `object_prob_threshold`, `cut_similarity`,
+  `cut_start`, `text_area_threshold`, `smooth_duration` accept any value with no
+  range checks. A negative/>1.0/NaN probability silently disables or breaks
+  detection/smoothing with no feedback.
+- **Suggestion:** add a `validate()` on `Args` (or checks early in `main`)
+  bounding probabilities/similarities to `[0,1]`, requiring non-negative
+  durations/percentages, rejecting NaN, bailing with a clear message.
+
+### Add unit tests for the remaining correctness-critical logic
+- **Impact:** medium · **Effort:** medium · **Kind:** robustness
+- **Where:** `image.rs` `is_cut` thresholds; `history_smoothing_video_processor.rs`
+  `select_closest_crop`/interpolation-length decision tree
+- **Why:** `parse_frame_rate`, `clamp_crop_rect`, and the three-head selection now
+  have tests, but the three-threshold cut decision and the crop-selection decision
+  tree (incl. the `smooth_duration_frames / 4` integer-division edge that silently
+  becomes 0 for durations < 4 frames) are still untested.
+- **Suggestion:** add focused tests for `is_cut` threshold transitions and the
+  `crop_to_use` branches, including the `/4` truncation edge (use
+  `(smooth_duration_frames / 4).max(1)` or float math).
+
+### Use `highest_confidence_ball.clone()` instead of rebuilding via `from_cxcywh`
+- **Impact:** low · **Effort:** small · **Kind:** robustness
+- **Where:** `ball_video_processor.rs` (multi-ball path)
+- **Why:** the single-ball path stores `objects[0].clone()`, but the multi-ball
+  path reconstructs the `Hbb` via `Hbb::from_cxcywh(...)`, dropping
+  confidence/class metadata and converting through center coords.
+  `predict_current_hbb` keys off `xmin`/`ymin`, so mixing a `from_cxcywh`-derived
+  box with directly-cloned boxes across frames can inject rounding noise into the
+  velocity/acceleration prediction.
+- **Suggestion:** store `highest_confidence_ball.clone()` (same as the single-ball path).
+
+---
+
+## Theme: Clarity & dead code
+
+### Encode stacked-layout intent in the type instead of float aspect sniffing
+- **Impact:** medium · **Effort:** medium · **Kind:** design
+- **Where:** `image.rs` (stacked-crop layout selection) ↔ `crop.rs` (stack geometry)
+- **Why:** the renderer re-derives the three-head 9:6 / 9:10 case by comparing
+  aspect ratios against `1.5`/`0.9` with ±0.1 tolerance, coupling `image.rs` to
+  magic constants in `crop.rs`. If crop geometry shifts slightly, the renderer
+  silently falls into the equal-half-height default and stacks wrong. The layout
+  is known at crop-calc time but thrown away and reverse-engineered.
+- **Suggestion:** add a `StackLayout` enum to the `Stacked` `CropResult` variant
+  (e.g. `Equal | TopWideBottomNarrow`) so the renderer matches on intent.
+
+### Name the `0.15` always-cut magic number and fix stale docs
+- **Impact:** low · **Effort:** small · **Kind:** design
+- **Where:** `image.rs` `CutDetector`
+- **Why:** `always_cut_threshold = 0.15` is hardcoded alongside the configurable
+  thresholds, and the `CutDetector::new` doc-comment still claims defaults of
+  0.15/0.7 that don't match the real CLI defaults (`cut_similarity` 0.4 /
+  `cut_start` 0.8).
+- **Suggestion:** promote `0.15` to a named const (or constructor param), update
+  the doc-comment to the real defaults, and document how the three thresholds interact.
+
+### Factory for processor selection; rename `viewer` → `sink`
+- **Impact:** low · **Effort:** small · **Kind:** simplification
+- **Where:** `main.rs` (processor selection); `video_processor.rs` (the `viewer` binding/params)
+- **Why:** processor selection is a three-arm `if/else` each duplicating
+  `processor.process_video(&args, &processed_video)?`. Separately, after the usls
+  migration the encoder/sink is still named `viewer` everywhere, obscuring its
+  primary encoder role.
+- **Suggestion:** add `fn make_processor(args) -> Box<dyn VideoProcessor>` and call
+  `process_video` once; rename the `viewer` binding and trait params to `sink`.
+
+### Clean up the lazy-encoder access and dead audio code
+- **Impact:** low · **Effort:** small · **Kind:** simplification
+- **Where:** `video_sink.rs` (encoder `expect`); `audio.rs` (`border_style` match, stray `println!`)
+- **Why:** `write_frame` inits the encoder then re-accesses it with
+  `.as_mut().expect("…")` — a latent panic on a self-maintained invariant.
+  Separately, `audio.rs` collapses three `border_style` arms to the same value and
+  unconditionally `println!`s `filter_str` on every caption burn (debug noise).
+- **Suggestion:** bind the encoder via a single `get_or_insert`-style path so
+  there's one access and no `expect`; simplify `border_style` and route
+  `filter_str` through `debug_println` (or remove it).
+
+### Make OCR/audio failure modes clearer
+- **Impact:** medium · **Effort:** small · **Kind:** robustness
+- **Where:** `audio.rs` `extract_audio`; `config.rs` `get_model_path`
+- **Why:** `extract_audio` uses `-acodec copy` into an `.mp4` container; for many
+  source codecs, or a source with no audio stream, this fails cryptically or
+  yields a file that breaks `combine_video_audio`. Separately, `get_model_path`
+  silently falls back to the default model for an unsupported `--ver`/`--scale`.
+- **Suggestion:** `ffprobe` for an audio stream first and either skip captioning
+  gracefully or bail clearly; in `get_model_path`, emit a warning when falling
+  back to the default model.

--- a/src/crop.rs
+++ b/src/crop.rs
@@ -280,13 +280,12 @@ pub fn calculate_three_heads_crop(
         let size_ratio = max_area / min_area;
         let similar_size = size_ratio <= 2.5;
 
-        // Check if heads are roughly equally spaced across the screen
-        let centers: Vec<f32> = heads.iter().map(|h| h.cx()).collect();
-        let sorted_centers = {
-            let mut centers = centers.clone();
-            centers.sort_by(|a, b| a.partial_cmp(b).unwrap());
-            centers
-        };
+        // Sort the head references left-to-right by horizontal center (NaN-safe),
+        // and reuse that ordering for both the spacing check and the
+        // left/middle/right identification below.
+        let mut sorted_heads = heads.to_vec();
+        sorted_heads.sort_by(|a, b| a.cx().total_cmp(&b.cx()));
+        let sorted_centers: Vec<f32> = sorted_heads.iter().map(|h| h.cx()).collect();
 
         let spacing1 = sorted_centers[1] - sorted_centers[0];
         let spacing2 = sorted_centers[2] - sorted_centers[1];
@@ -300,23 +299,10 @@ pub fn calculate_three_heads_crop(
             let single_width = stack_height * 0.9; // 9:10 aspect ratio
             let default_y = frame_height * 0.1; // 10% from top
 
-            // Identify heads corresponding to sorted centers
-            let left_center = sorted_centers[0];
-            let middle_center = sorted_centers[1];
-            let right_center = sorted_centers[2];
-
-            let left_head = *heads
-                .iter()
-                .find(|h| (h.cx() - left_center).abs() < 1.0)
-                .unwrap();
-            let middle_head = *heads
-                .iter()
-                .find(|h| (h.cx() - middle_center).abs() < 1.0)
-                .unwrap();
-            let right_head = *heads
-                .iter()
-                .find(|h| (h.cx() - right_center).abs() < 1.0)
-                .unwrap();
+            // Heads in left-to-right order (no fragile tolerance matching).
+            let left_head = sorted_heads[0];
+            let middle_head = sorted_heads[1];
+            let right_head = sorted_heads[2];
 
             let left_area = left_head.width() * left_head.height();
             let right_area = right_head.width() * right_head.height();
@@ -733,6 +719,39 @@ pub fn select_closest_crop<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_three_heads_nan_center_does_not_panic() {
+        // A degenerate head with a NaN center must not crash the sort/selection.
+        let frame_width = 1920.0;
+        let frame_height = 1080.0;
+        let h1 = Hbb::from_xywh(100.0, 400.0, 200.0, 200.0); // cx 200
+        let h2 = Hbb::from_xywh(1600.0, 400.0, 200.0, 200.0); // cx 1700 (wide bbox -> stack path)
+        let h3 = Hbb::from_xywh(f32::NAN, 400.0, 200.0, 200.0); // cx NaN
+        let heads = [&h1, &h2, &h3];
+        // Must return without panicking.
+        let _ = calculate_three_heads_crop(true, frame_width, frame_height, &heads);
+    }
+
+    #[test]
+    fn test_three_heads_selection_is_order_independent() {
+        // Three similar, equally-spaced, widely-separated heads -> stacked path.
+        let frame_width = 1920.0;
+        let frame_height = 1080.0;
+        let left = Hbb::from_xywh(300.0, 400.0, 200.0, 200.0); // cx 400
+        let middle = Hbb::from_xywh(860.0, 400.0, 200.0, 200.0); // cx 960
+        let right = Hbb::from_xywh(1420.0, 400.0, 200.0, 200.0); // cx 1520
+
+        let sorted =
+            calculate_three_heads_crop(true, frame_width, frame_height, &[&left, &middle, &right]);
+        let scrambled =
+            calculate_three_heads_crop(true, frame_width, frame_height, &[&right, &left, &middle]);
+
+        // Left/middle/right identification must not depend on input order.
+        assert_eq!(format!("{sorted:?}"), format!("{scrambled:?}"));
+        // And this configuration must take the stacked path.
+        assert!(matches!(sorted, CropResult::Stacked(_, _)));
+    }
 
     #[test]
     fn test_calculate_bounding_box() {

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,4 +1,5 @@
 use crate::crop::CropResult;
+use std::collections::VecDeque;
 use usls::Image;
 
 /// A structure to hold frame data including crop, image, and head count
@@ -11,36 +12,34 @@ pub struct FrameData {
 
 /// A structure to maintain a history of frame data
 pub struct CropHistory {
-    frames: Vec<FrameData>,
+    frames: VecDeque<FrameData>,
 }
 
 impl CropHistory {
     /// Create a new empty history
     pub fn new() -> Self {
-        Self { frames: Vec::new() }
+        Self {
+            frames: VecDeque::new(),
+        }
     }
 
     /// Add a new frame to the history
     pub fn add(&mut self, crop: CropResult, image: Image, object_count: usize) {
-        self.frames.push(FrameData {
+        self.frames.push_back(FrameData {
             crop,
             image,
             object_count,
         });
     }
 
-    /// Remove and return the first frame from the history
+    /// Remove and return the first frame from the history (O(1))
     pub fn pop_front(&mut self) -> Option<FrameData> {
-        if self.frames.is_empty() {
-            None
-        } else {
-            Some(self.frames.remove(0))
-        }
+        self.frames.pop_front()
     }
 
     /// Get a reference to the first frame without removing it
     pub fn peek_front(&self) -> Option<&FrameData> {
-        self.frames.first()
+        self.frames.front()
     }
 
     /// Get the number of frames in the history
@@ -51,5 +50,38 @@ impl CropHistory {
     /// Check if the history is empty
     pub fn is_empty(&self) -> bool {
         self.frames.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crop::{CropArea, CropResult};
+    use image::RgbImage;
+
+    fn dummy_image() -> Image {
+        Image::from(RgbImage::new(2, 2))
+    }
+
+    #[test]
+    fn test_history_is_fifo() {
+        let mut history = CropHistory::new();
+        assert!(history.is_empty());
+
+        for i in 0..3 {
+            history.add(
+                CropResult::Single(CropArea::new(0.0, 0.0, 2.0, 2.0)),
+                dummy_image(),
+                i,
+            );
+        }
+
+        assert_eq!(history.len(), 3);
+        assert_eq!(history.peek_front().unwrap().object_count, 0);
+        assert_eq!(history.pop_front().unwrap().object_count, 0);
+        assert_eq!(history.pop_front().unwrap().object_count, 1);
+        assert_eq!(history.pop_front().unwrap().object_count, 2);
+        assert!(history.pop_front().is_none());
+        assert!(history.is_empty());
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,5 +1,6 @@
 use crate::crop::CropResult;
 use crate::video_processor_utils;
+use crate::video_sink::make_even;
 use anyhow::Result;
 use image::{RgbImage, imageops::resize};
 use usls::Image;
@@ -36,12 +37,9 @@ impl CutDetector {
     /// `true` if the similarity is less than similarity_threshold AND previous_score is greater than previous_similarity_threshold,
     /// `false` otherwise
     pub fn is_cut(&mut self, image1: &Image, image2: &Image) -> Result<bool> {
-        // Convert both images to RgbImage for comparison
-        let rgb1 = image1.to_rgb8();
-        let rgb2 = image2.to_rgb8();
-
-        // Use rgb_image_compare to get the similarity score
-        let similarity = image_compare::rgb_hybrid_compare(&rgb1, &rgb2)?;
+        // Compare the inner RgbImage buffers directly (Image derefs to RgbImage),
+        // avoiding a full-frame clone of each image every frame.
+        let similarity = image_compare::rgb_hybrid_compare(&image1.image, &image2.image)?;
         let current_score = similarity.score;
 
         video_processor_utils::debug_println(format_args!("similarity: {:?}", current_score));
@@ -68,6 +66,26 @@ impl CutDetector {
     }
 }
 
+/// Clamps a crop rectangle (produced by float crop math, which can go out of
+/// bounds for non-landscape or degenerate inputs) to valid integer pixel bounds
+/// inside a `frame_w` x `frame_h` frame. Guarantees `x + width <= frame_w`,
+/// `y + height <= frame_h`, and `width, height >= 1`, so the result is always a
+/// safe argument to `imageops::crop`.
+fn clamp_crop_rect(
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    frame_w: u32,
+    frame_h: u32,
+) -> (u32, u32, u32, u32) {
+    let x = (x.max(0.0) as u32).min(frame_w.saturating_sub(1));
+    let y = (y.max(0.0) as u32).min(frame_h.saturating_sub(1));
+    let width = (width.max(0.0) as u32).min(frame_w - x).max(1);
+    let height = (height.max(0.0) as u32).min(frame_h - y).max(1);
+    (x, y, width, height)
+}
+
 /// Creates a new image by cropping the input image according to the crop result
 ///
 /// # Arguments
@@ -84,26 +102,28 @@ pub fn create_cropped_image(
     crop_result: &CropResult,
     target_width: u32,
 ) -> Result<Image> {
-    // Get the underlying RgbImage
-    let mut rgb_image = image.to_rgb8();
+    // Borrow the inner RgbImage directly (no clone); the crops are read-only.
+    let src = &image.image;
+    let (frame_w, frame_h) = src.dimensions();
+    // Snap the output width to even so the final H.264 yuv420p frame is valid.
+    let target_width = make_even(target_width);
 
     match crop_result {
         CropResult::Single(crop) => {
-            // For a single crop, crop the image to the specified area
-            let x = crop.x as u32;
-            let y = crop.y as u32;
-            let width = crop.width as u32;
-            let height = crop.height as u32;
+            // Clamp the (float) crop rect to valid pixel bounds before cropping.
+            let (x, y, width, height) =
+                clamp_crop_rect(crop.x, crop.y, crop.width, crop.height, frame_w, frame_h);
 
             // Use imageops::crop to get the cropped region
-            let cropped = image::imageops::crop(&mut rgb_image, x, y, width, height).to_image();
+            let cropped = image::imageops::crop_imm(src, x, y, width, height).to_image();
 
-            // Scale the cropped image to match target width if needed
+            // Scale the cropped image to match target width, preserving the
+            // actual (post-clamp) aspect ratio.
             let scaled = if cropped.width() != target_width {
                 resize(
                     &cropped,
                     target_width,
-                    (target_width as f32 * (height as f32 / width as f32)) as u32,
+                    (target_width as f32 * (cropped.height() as f32 / cropped.width() as f32)) as u32,
                     image::imageops::FilterType::Lanczos3,
                 )
             } else {
@@ -111,7 +131,7 @@ pub fn create_cropped_image(
             };
 
             // Create a new image with 9:16 aspect ratio and black background
-            let output_height = (target_width as f32 * (16.0 / 9.0)) as u32;
+            let output_height = make_even((target_width as f32 * (16.0 / 9.0)) as u32);
             let mut result = RgbImage::new(target_width, output_height);
 
             // Calculate y offset (1/16 of the height)
@@ -129,27 +149,17 @@ pub fn create_cropped_image(
             // 2. Scaling crops based on their aspect ratios
             // 3. Stacking them vertically to create the final 9:16 image
 
-            // Crop both areas from the source image
-            let crop1_img = image::imageops::crop(
-                &mut rgb_image,
-                crop1.x as u32,
-                crop1.y as u32,
-                crop1.width as u32,
-                crop1.height as u32,
-            )
-            .to_image();
+            // Crop both areas from the source image (rects clamped to bounds)
+            let (x1, y1, w1, h1) =
+                clamp_crop_rect(crop1.x, crop1.y, crop1.width, crop1.height, frame_w, frame_h);
+            let crop1_img = image::imageops::crop_imm(src, x1, y1, w1, h1).to_image();
 
-            let crop2_img = image::imageops::crop(
-                &mut rgb_image,
-                crop2.x as u32,
-                crop2.y as u32,
-                crop2.width as u32,
-                crop2.height as u32,
-            )
-            .to_image();
+            let (x2, y2, w2, h2) =
+                clamp_crop_rect(crop2.x, crop2.y, crop2.width, crop2.height, frame_w, frame_h);
+            let crop2_img = image::imageops::crop_imm(src, x2, y2, w2, h2).to_image();
 
             // Calculate the target 9:16 aspect ratio height
-            let target_height = (target_width as f32 * (16.0 / 9.0)) as u32;
+            let target_height = make_even((target_width as f32 * (16.0 / 9.0)) as u32);
 
             // Determine scaling strategy based on crop aspect ratios
             let crop1_aspect = crop1.width / crop1.height;
@@ -207,20 +217,19 @@ pub fn create_cropped_image(
         CropResult::Resize(crop) => {
             // For resize, we want to resize the entire frame to the target width
             // The crop area should cover the entire frame (x=0, y=0, width=frame_width, height=frame_height)
-            let x = crop.x as u32;
-            let y = crop.y as u32;
-            let width = crop.width as u32;
-            let height = crop.height as u32;
+            let (x, y, width, height) =
+                clamp_crop_rect(crop.x, crop.y, crop.width, crop.height, frame_w, frame_h);
 
             // Use imageops::crop to get the cropped region (should be the entire frame)
-            let cropped = image::imageops::crop(&mut rgb_image, x, y, width, height).to_image();
+            let cropped = image::imageops::crop_imm(src, x, y, width, height).to_image();
 
-            // Scale the cropped image to match target width if needed
+            // Scale the cropped image to match target width, preserving the
+            // actual (post-clamp) aspect ratio.
             let scaled = if cropped.width() != target_width {
                 resize(
                     &cropped,
                     target_width,
-                    (target_width as f32 * (height as f32 / width as f32)) as u32,
+                    (target_width as f32 * (cropped.height() as f32 / cropped.width() as f32)) as u32,
                     image::imageops::FilterType::Lanczos3,
                 )
             } else {
@@ -228,7 +237,7 @@ pub fn create_cropped_image(
             };
 
             // Create a new image with 9:16 aspect ratio and black background
-            let output_height = (target_width as f32 * (16.0 / 9.0)) as u32;
+            let output_height = make_even((target_width as f32 * (16.0 / 9.0)) as u32);
             let mut result = RgbImage::new(target_width, output_height);
 
             // Calculate y offset (1/8 of the height)
@@ -248,6 +257,45 @@ mod tests {
     use super::*;
     use crate::crop::CropArea;
     use usls::Image;
+
+    #[test]
+    fn test_clamp_crop_rect_in_bounds_unchanged() {
+        assert_eq!(
+            clamp_crop_rect(360.0, 0.0, 810.0, 1080.0, 1920, 1080),
+            (360, 0, 810, 1080)
+        );
+    }
+
+    #[test]
+    fn test_clamp_crop_rect_negative_origin() {
+        // Negative x/y floor to 0 without shrinking a width that still fits.
+        assert_eq!(
+            clamp_crop_rect(-50.0, -30.0, 810.0, 1080.0, 1920, 1080),
+            (0, 0, 810, 1080)
+        );
+    }
+
+    #[test]
+    fn test_clamp_crop_rect_overflow_width_height() {
+        // x+width past the right edge clamps width to what remains.
+        assert_eq!(
+            clamp_crop_rect(1500.0, 0.0, 810.0, 1080.0, 1920, 1080),
+            (1500, 0, 420, 1080)
+        );
+        // y+height past the bottom edge clamps height to what remains.
+        assert_eq!(
+            clamp_crop_rect(0.0, 1000.0, 810.0, 500.0, 1920, 1080),
+            (0, 1000, 810, 80)
+        );
+    }
+
+    #[test]
+    fn test_clamp_crop_rect_degenerate_is_at_least_one_pixel() {
+        // Zero-size box becomes a 1x1 region rather than a panic/empty crop.
+        assert_eq!(clamp_crop_rect(100.0, 100.0, 0.0, 0.0, 1920, 1080), (100, 100, 1, 1));
+        // Origin far beyond the frame still yields a valid 1x1 region in-bounds.
+        assert_eq!(clamp_crop_rect(5000.0, 5000.0, 100.0, 100.0, 1920, 1080), (1919, 1079, 1, 1));
+    }
 
     #[test]
     fn test_single_crop() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,20 @@ mod video_processor;
 mod video_processor_utils;
 mod video_sink;
 
+/// Validates that `--source` refers to something we can read before doing any
+/// work, so a typo fails fast with a clear message instead of a cryptic ffmpeg
+/// or DataLoader error after the run directory has already been created.
+/// Network/stream sources (containing `://`) are assumed valid and not checked.
+fn validate_source(source: &str) -> Result<()> {
+    if source.contains("://") {
+        return Ok(());
+    }
+    if !Path::new(source).exists() {
+        anyhow::bail!("source video not found: {source}");
+    }
+    Ok(())
+}
+
 /// Creates a timestamped output directory and returns its path
 fn create_output_dir() -> Result<String> {
     let timestamp = Local::now().format("%Y%m%d_%H%M%S_%f").to_string();
@@ -29,6 +43,9 @@ fn create_output_dir() -> Result<String> {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args: cli::Args = argh::from_env();
+
+    // Fail fast on a missing source before creating run dirs or extracting audio.
+    validate_source(&args.source)?;
 
     // Create timestamped output directory
     let output_dir = create_output_dir()?;
@@ -139,4 +156,29 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_source_missing_path_errors() {
+        assert!(validate_source("/no/such/file/really.mp4").is_err());
+    }
+
+    #[test]
+    fn test_validate_source_existing_path_ok() {
+        let path = std::env::temp_dir().join("land2port_validate_source_test.tmp");
+        fs::write(&path, b"x").unwrap();
+        let result = validate_source(path.to_str().unwrap());
+        let _ = fs::remove_file(&path);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_source_url_is_skipped() {
+        assert!(validate_source("rtsp://example.com/stream").is_ok());
+        assert!(validate_source("http://example.com/video.mp4").is_ok());
+    }
 }

--- a/src/video_processor.rs
+++ b/src/video_processor.rs
@@ -4,6 +4,7 @@ use crate::crop;
 use crate::video_processor_utils;
 use crate::video_sink::{self, VideoSink};
 use anyhow::Result;
+use std::borrow::Cow;
 use usls::{
     Annotator, Config, DataLoader, HbbStyle, Model, ObbStyle,
     models::{DB, YOLO},
@@ -74,10 +75,12 @@ pub trait VideoProcessor {
             let detections = model.forward(&images)?;
 
             for (image, detection) in images.iter().zip(detections.iter()) {
-                let mut img = if !args.headless {
-                    annotator.annotate(image, detection)?
+                // Only the annotated (non-headless) path needs an owned image;
+                // headless borrows the DataLoader's frame to skip a full clone.
+                let mut img: Cow<usls::Image> = if !args.headless {
+                    Cow::Owned(annotator.annotate(image, detection)?)
                 } else {
-                    image.clone()
+                    Cow::Borrowed(image)
                 };
 
                 // Calculate crop areas based on the detection results
@@ -93,7 +96,7 @@ pub trait VideoProcessor {
 
                         if !ys[0].hbbs.is_empty() {
                             if !args.headless {
-                                img = textannotator.annotate(&img, &ys[0])?;
+                                img = Cow::Owned(textannotator.annotate(&img, &ys[0])?);
                             }
                             video_processor_utils::is_graphic_area_above_threshold(
                                 ys[0].hbbs.iter(),
@@ -149,6 +152,13 @@ pub trait VideoProcessor {
             }
         }
         self.finalize_processing(args, &mut viewer)?;
+
+        // Surface an empty/unreadable source here, rather than letting main.rs
+        // fail later on a missing output file with a confusing copy error.
+        if viewer.frame_count() == 0 {
+            anyhow::bail!("no frames were written from source {}", args.source);
+        }
+
         viewer.finalize()?;
 
         perf_chart();

--- a/src/video_processor_utils.rs
+++ b/src/video_processor_utils.rs
@@ -27,7 +27,7 @@ pub fn process_and_display_crop(
     headless: bool,
 ) -> Result<()> {
     let cropped_img = image::create_cropped_image(img, crop_result, img.height() as u32)?;
-    viewer.write_frame(&cropped_img, headless)?;
+    viewer.write_frame(cropped_img, headless)?;
     Ok(())
 }
 

--- a/src/video_sink.rs
+++ b/src/video_sink.rs
@@ -40,33 +40,37 @@ impl VideoSink {
         self.viewer.is_window_exist_and_closed()
     }
 
-    /// Displays (unless headless) and encodes one output frame.
+    /// Displays (unless headless) and encodes one output frame, consuming it.
     ///
-    /// The encoder is created lazily from the first frame's dimensions, mirroring
-    /// how the usls `Viewer` itself initializes encoding. Output frame timing is
-    /// derived from a monotonic frame counter at the source fps, matching the old
-    /// `Viewer::with_fps` behavior.
-    pub fn write_frame(&mut self, img: &Image, headless: bool) -> Result<()> {
+    /// Takes the cropped image by value so the pixel buffer can be moved into the
+    /// encoder (`into_rgb8`) rather than cloned. The encoder is created lazily
+    /// from the first frame's dimensions, mirroring how the usls `Viewer` itself
+    /// initializes encoding. Output frame timing is derived from a monotonic
+    /// frame counter at the source fps, matching the old `Viewer::with_fps`.
+    pub fn write_frame(&mut self, img: Image, headless: bool) -> Result<()> {
         if !headless {
-            self.viewer.imshow(img)?;
+            self.viewer.imshow(&img)?;
         }
 
-        let rgb = img.to_rgb8();
+        let rgb = img.into_rgb8();
         let (w, h) = (rgb.width() as usize, rgb.height() as usize);
 
         if self.encoder.is_none() {
             let settings = Settings::preset_h264_yuv420p(w, h, false);
             self.encoder = Some(Encoder::new(self.saveout.clone(), settings)?);
         }
+        let encoder = self.encoder.as_mut().expect("encoder initialized above");
 
         let frame = Frame::from_shape_vec((h, w, 3), rgb.into_raw())?;
         let timestamp = Time::from_secs_f64(self.frame_index as f64 / self.fps);
-        self.encoder
-            .as_mut()
-            .expect("encoder initialized above")
-            .encode(&frame, timestamp)?;
+        encoder.encode(&frame, timestamp)?;
         self.frame_index += 1;
         Ok(())
+    }
+
+    /// Number of frames encoded so far.
+    pub fn frame_count(&self) -> usize {
+        self.frame_index
     }
 
     /// Flushes and closes the encoder, finalizing the output file.
@@ -78,12 +82,54 @@ impl VideoSink {
     }
 }
 
-/// Reads the average frame rate of `source` via `ffprobe`, falling back to 30.0
-/// fps if it can't be determined (e.g. for non-file sources). The new usls
-/// `DataLoader` no longer exposes the source frame rate, so we probe it here.
-pub fn probe_fps(source: &str) -> f64 {
-    const DEFAULT_FPS: f64 = 30.0;
+impl Drop for VideoSink {
+    fn drop(&mut self) {
+        // Ensure the mp4 is finalized (moov atom written, packets flushed) even
+        // if the processing loop exits early via an error or panic before the
+        // explicit finalize() runs. A successful finalize() already took the
+        // encoder, so this is a no-op on the happy path. Errors can't propagate
+        // out of drop, so they are logged.
+        if let Some(mut encoder) = self.encoder.take() {
+            if let Err(err) = encoder.finish() {
+                eprintln!("warning: failed to finalize video output on drop: {err}");
+            }
+        }
+    }
+}
 
+const DEFAULT_FPS: f64 = 30.0;
+const MIN_FPS: f64 = 1.0;
+const MAX_FPS: f64 = 240.0;
+
+/// Parses an ffprobe frame-rate field into fps. The field is a rational like
+/// `"30000/1001"` or `"30/1"`, occasionally a bare number, and `"0/0"` when the
+/// stream doesn't report one. Returns `None` for anything unparseable or zero.
+pub fn parse_frame_rate(text: &str) -> Option<f64> {
+    let text = text.trim();
+    if let Some((num, den)) = text.split_once('/') {
+        let num: f64 = num.trim().parse().ok()?;
+        let den: f64 = den.trim().parse().ok()?;
+        if num == 0.0 || den == 0.0 {
+            return None;
+        }
+        Some(num / den)
+    } else {
+        let fps: f64 = text.parse().ok()?;
+        (fps != 0.0).then_some(fps)
+    }
+}
+
+/// Snaps a dimension down to the nearest even number (minimum 2), as required by
+/// H.264 yuv420p, which mandates even width and height.
+pub fn make_even(dim: u32) -> u32 {
+    (dim & !1).max(2)
+}
+
+/// Reads the average frame rate of `source` via `ffprobe`, falling back to 30
+/// fps (with a warning) if it can't be determined. The new usls `DataLoader`
+/// no longer exposes the source frame rate, so we probe it here. The result is
+/// clamped to a sane range, since fps drives both output timing and smoothing.
+pub fn probe_fps(source: &str) -> f64 {
     let output = Command::new("ffprobe")
         .args([
             "-v",
@@ -91,31 +137,78 @@ pub fn probe_fps(source: &str) -> f64 {
             "-select_streams",
             "v:0",
             "-show_entries",
-            "stream=r_frame_rate",
+            "stream=avg_frame_rate",
             "-of",
             "csv=p=0",
         ])
         .arg(source)
         .output();
 
-    let Ok(output) = output else {
-        return DEFAULT_FPS;
+    let output = match output {
+        Ok(output) if output.status.success() => output,
+        Ok(output) => {
+            eprintln!(
+                "warning: ffprobe exited with {} for {source:?}; defaulting to {DEFAULT_FPS} fps",
+                output.status
+            );
+            return DEFAULT_FPS;
+        }
+        Err(err) => {
+            eprintln!(
+                "warning: could not run ffprobe ({err}) for {source:?}; defaulting to {DEFAULT_FPS} fps"
+            );
+            return DEFAULT_FPS;
+        }
     };
 
-    // r_frame_rate is reported as a rational, e.g. "30000/1001" or "30/1".
     let text = String::from_utf8_lossy(&output.stdout);
-    let text = text.trim();
-    if let Some((num, den)) = text.split_once('/') {
-        if let (Ok(num), Ok(den)) = (num.parse::<f64>(), den.parse::<f64>()) {
-            if den != 0.0 && num != 0.0 {
-                return num / den;
-            }
-        }
-    } else if let Ok(fps) = text.parse::<f64>() {
-        if fps != 0.0 {
-            return fps;
+    match parse_frame_rate(&text) {
+        Some(fps) => fps.clamp(MIN_FPS, MAX_FPS),
+        None => {
+            eprintln!(
+                "warning: could not parse frame rate from ffprobe output {:?} for {source:?}; defaulting to {DEFAULT_FPS} fps",
+                text.trim()
+            );
+            DEFAULT_FPS
         }
     }
+}
 
-    DEFAULT_FPS
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_frame_rate_rational() {
+        assert!((parse_frame_rate("30000/1001").unwrap() - 29.97).abs() < 0.01);
+        assert!((parse_frame_rate("24000/1001").unwrap() - 23.976).abs() < 0.01);
+        assert_eq!(parse_frame_rate("25/1"), Some(25.0));
+        assert_eq!(parse_frame_rate("30/1"), Some(30.0));
+    }
+
+    #[test]
+    fn test_parse_frame_rate_bare_and_whitespace() {
+        assert_eq!(parse_frame_rate("25"), Some(25.0));
+        assert_eq!(parse_frame_rate("  60/1\n"), Some(60.0));
+    }
+
+    #[test]
+    fn test_parse_frame_rate_invalid() {
+        assert_eq!(parse_frame_rate("0/0"), None);
+        assert_eq!(parse_frame_rate("30/0"), None);
+        assert_eq!(parse_frame_rate("0/1"), None);
+        assert_eq!(parse_frame_rate(""), None);
+        assert_eq!(parse_frame_rate("garbage"), None);
+        assert_eq!(parse_frame_rate("abc/def"), None);
+    }
+
+    #[test]
+    fn test_make_even() {
+        assert_eq!(make_even(1080), 1080);
+        assert_eq!(make_even(1081), 1080);
+        assert_eq!(make_even(3), 2);
+        assert_eq!(make_even(2), 2);
+        assert_eq!(make_even(1), 2);
+        assert_eq!(make_even(0), 2);
+    }
 }


### PR DESCRIPTION
Implements the high-value **robustness + per-frame allocation** cluster from the multi-agent code review, and adds a backlog doc tracking the remaining findings.

## Robustness (TDD — tests first where unit-testable)
- **Encoder finalize on every exit path** via a `Drop` guard — an error/panic mid-loop no longer leaves a corrupt mp4 (moov atom unwritten).
- **Surface the `probe_fps` fallback** — check ffprobe exit status, warn on fallback, query `avg_frame_rate`, clamp to a sane range. Prevents silent wrong-speed / audio drift.
- **Clamp every crop rect to frame bounds** before `imageops::crop`, and snap output dims to even (H.264 yuv420p) — fixes malformed frames / panics on non-landscape or degenerate boxes; resize target uses post-clamp dims.
- **Three-head selection** identifies heads by sorting refs with `total_cmp` instead of a tolerance match + `unwrap` (NaN-safe, order-independent). Driven by a test that genuinely panicked first.
- **Validate `--source`** up front (skipping network sources) so typos fail fast instead of after the run dir / audio extraction; **bail on a zero-frame run**.

## Performance (refactored under existing green tests)
- `write_frame` takes the cropped image by value + `into_rgb8` (move, not clone); `create_cropped_image` borrows the inner `RgbImage` and uses `crop_imm` — removes ~2 full-frame copies/frame.
- Cut detection compares inner buffers directly (no per-frame clones); headless path borrows the frame via `Cow`.
- `CropHistory` backed by `VecDeque` for O(1) `pop_front`.

> Honest note: profiling showed the pipeline is **video-decode-bound** (~37s of a ~40s run is ffmpeg decode inside the usls `DataLoader`), so these allocation cuts reduce CPU/allocator pressure but do **not** measurably change wall-clock on this workload. A VideoToolbox hardware-decode spike was tried and reverted — a net loss, because the DataLoader already pipelines software decode on a background thread.

## Tests
New unit tests: `parse_frame_rate`, `make_even`, `clamp_crop_rect`, three-head NaN/order-independence, source validation, history FIFO. **65 tests pass** (was 51). End-to-end output unchanged (1080x1920 9:16 at source fps).

## Docs
`docs/code-review-findings.md` tracks the remaining design/quality + lower-leverage perf findings (smoothing semantics #11–#13, shared state #19, history memory #23, OCR batching #21, resize filter #26, etc.) that were intentionally deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)